### PR TITLE
added rows where bs.south -> sebs & bs.all -> nebs

### DIFF
--- a/data/placenames.csv
+++ b/data/placenames.csv
@@ -13,9 +13,29 @@ islands,bs.south,St. Lawrence,-170.3,63.4
 bathymetry,bs.south,200 m,-173.5,58
 bathymetry,bs.south,100 m,-171.7,58
 bathymetry,bs.south,50 m,-165.5,58
-convention line,bs.south,U.S.�Russia Maritime Boundary,-177.6,61.6
-convention line,bs.all,U.S.�Russia Maritime Boundary,-175,63.25
+convention line,bs.south,U.S.–Russia Maritime Boundary,-177.6,61.6
+convention line,bs.all,U.S.–Russia Maritime Boundary,-175,63.25
 mainland,bs.south,Alaska,-160,61.7
 mainland,bs.all,Alaska,-160,61.7
 peninsula,bs.all,Alaska Peninsula,-160.4,56.2
 peninsula,bs.south,Alaska Peninsula,-160.4,56.2
+islands,nebs,Pribilof Isl.,-170,56.9
+islands,nebs,Nunivak,-166.25,60.1
+islands,nebs,St. Matthew,-172.66,60.4
+islands,nebs,St. Lawrence,-170.3,63.4
+bathymetry,nebs,200 m,-173.5,58
+bathymetry,nebs,100 m,-171.7,58
+bathymetry,nebs,50 m,-165.5,58
+islands,sebs,Pribilof Isl.,-170,56.9
+islands,sebs,Nunivak,-166.25,60.1
+islands,sebs,St. Matthew,-172.66,60.4
+islands,sebs,St. Lawrence,-170.3,63.4
+bathymetry,sebs,200 m,-173.5,58
+bathymetry,sebs,100 m,-171.7,58
+bathymetry,sebs,50 m,-165.5,58
+convention line,sebs,U.S.–Russia Maritime Boundary,-177.6,61.6
+convention line,nebs,U.S.–Russia Maritime Boundary,-175,63.25
+mainland,sebs,Alaska,-160,61.7
+mainland,nebs,Alaska,-160,61.7
+peninsula,nebs,Alaska Peninsula,-160.4,56.2
+peninsula,sebs,Alaska Peninsula,-160.4,56.2


### PR DESCRIPTION
Without these changes you can only use bs.all or bs.south to return place.labels and not nebs or sebs, respectively. I'll probably add something about expanding this for nbs/bs.north later on. 

e.g., in get_base_layers():
place.labels <- read.csv(file = system.file("data", 
        "placenames.csv", package = "akgfmaps")) %>% 
        dplyr::filter(region == select.region) %>% akgfmaps::transform_data_frame_crs(out.crs = set.crs)