### PR TITLE
nbs extrap.box values & extrap.box default = NULL

### DIFF
--- a/R/make_idw_map.R
+++ b/R/make_idw_map.R
@@ -37,7 +37,7 @@ make_idw_map <- function(x = NA,
                          LONGITUDE = NA, 
                          CPUE_KGHA = NA, 
                          region = "bs.south", 
-                         extrap.box = NA, 
+                         extrap.box = NULL, 
                          set.breaks = "jenks", 
                          grid.cell = c(0.05, 0.05), 
                          in.crs = "+proj=longlat", 
@@ -62,8 +62,9 @@ make_idw_map <- function(x = NA,
   }
   
   # Set up mapping region---------------------------------------------------------------------------
-  if(is.na(extrap.box)[1]) {
+  if(is.null(extrap.box)) {
     if(region %in% c("bs.south", "sebs")) {extrap.box = c(xmn = -179.5, xmx = -157, ymn = 54, ymx = 63)}
+    if(region %in% c("bs.north", "nbs")) {extrap.box = c(xmn = -179.5, xmx = -157, ymn = 54, ymx = 68)}
     if(region %in% c("bs.all", "ebs")) {extrap.box = c(xmn = -179.5, xmx = -157, ymn = 54, ymx = 68)}
   }
   


### PR DESCRIPTION
Added nbs extrap.box values and changed function default value of extrap.box to NULL, which can be a little easier to handle than is.na(extrap.box)[1] because is.null(extrap.box) will simply be FALSE regardless of what extrap.box is as long as it is not actually NULL. Also, I wonder if this exact script was not pushed out of the dev branch (assuming you have one?) because when I explored the function in R after a fresh download of the package, it read "if (is.na(extrap.box)) {" without the "[1]", which was present here.